### PR TITLE
fix: correct label for inherited roles

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -27,7 +27,7 @@ AddEventHandler("BadgerVehicles:CheckPermission", function()
                                 -- There is inheritted roles 
                                 for j = 1, #inheritedRoles do 
                                     userRoles[ inheritedRoles[j] ] = true;
-                                    print("[DiscordVehicleRestrictions] " .. GetPlayerName(src) .. " has inherited role: " .. tostring(role) );
+                                    print("[DiscordVehicleRestrictions] " .. GetPlayerName(src) .. " has inherited role: " .. tostring(inheritedRoles[j]) );
                                 end
                             end
                         end


### PR DESCRIPTION
before:
![](https://cdn.izmystic.dev/images/bjcjcmk6.png)

after:
![](https://cdn.izmystic.dev/images/cabnjaz8.png)